### PR TITLE
make the redis password in settings.local.php optional

### DIFF
--- a/resources/runner/drupal.yml
+++ b/resources/runner/drupal.yml
@@ -194,7 +194,7 @@ drupal:
         $settings['redis.connection']['interface'] = getenv('REDIS_INTERFACE');
         $settings['redis.connection']['host'] = getenv('REDIS_HOST');
         $settings['redis.connection']['port'] = getenv('REDIS_PORT');
-        $settings['redis.connection']['password'] = getenv('REDIS_PASSWORD');
+        if(getenv('REDIS_PASSWORD')) { $settings['redis.connection']['password'] = getenv('REDIS_PASSWORD'); }
         $settings['cache']['default'] = 'cache.backend.redis';
         $settings['container_yamls'][] = DRUPAL_ROOT . '/modules/contrib/redis/example.services.yml';
       Custom error handler: |


### PR DESCRIPTION
During the migration to AWS, we have an issues.

REDIS password is not supported in Elasticache/redis.

Because the setting for a redis password is not optional in the configuration, I get an error on AWS.

Therefore, I added a check to only add the redis password configuration when the environment variable 'REDIS_PASSWORD' is set.

**Please first test this since I am not in a position to test this myself!**